### PR TITLE
Fix the handling of single quotes in the wrapper script

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -9,11 +9,10 @@ arch = case RUBY_PLATFORM
     raise 'Invalid platform. Must be running Linux, Alpine Linux or Intel-based Mac OS.'
 end
 
-args = $*.map { |x| x.include?(' ') ? "'" + x + "'" : x }
 cmd = File.expand_path "#{File.dirname(__FILE__)}/../libexec/wkhtmltopdf-#{arch}"
 
 begin
-  exec "#{cmd} #{args.join(' ')}"
+  exec cmd, *ARGV
 rescue Errno::ENOENT => e
   raise "Not found or wkhtmltopdf binaries might be incompatible with the os version \n #{e}"
 end


### PR DESCRIPTION
There's a flaw in how bin/wkhtmltopdf handles single quotes.

```shell-session
% bin/wkhtmltopdf --title "User's Guide" file:///path/to/html /tmp/output.pdf
sh: -c: line 0: unexpected EOF while looking for matching `''
sh: -c: line 1: syntax error: unexpected end of file
```

This can lead to security vulnerability when the user of this package
passes an untrusted string to the bin/wkhtmltopdf command.